### PR TITLE
Add missing devices to docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -148,12 +148,15 @@
                             <li>K70 RAPIDFIRE</li>
                             <li>K70 LUX RGB</li>
                             <li>K70 RGB RAPIDFIRE</li>
+                            <li>K70 RGB MK.2</li>
                             <li>K95 RGB</li>
                             <li>STRAFE</li>
                             <li>STRAFE RGB</li>
+                            <li>STRAFE RGB MK.2</li>
                             <li>K63</li>
                             <li>K68</li>
                             <li>K95 RGB PLATINUM</li>
+                            <li>K95 RGB PLATINUM XT</li>
                             <li>K55 RGB</li>
                         </ul>
                     </li>
@@ -161,13 +164,16 @@
                         <ul>
                             <li>M65 RGB</li>
                             <li>M65 PRO RGB</li>
+                            <li>M65 ELITE RGB</li>
                             <li>SABRE</li>
                             <li>SABRE RGB</li>
                             <li>SABRE RGB Optical</li>
                             <li>SABRE RGB Laser</li>
-                            <li>Scimitar</li>
                             <li>GLAIVE RGB</li>
+                            <li>Scimitar RGB</li>
                             <li>Scimitar PRO RGB</li>
+                            <li>Scimitar ELITE RGB</li>
+                            <li>IRONCLAW RGB</li>
                             <li>KATAR</li>
                             <li>HARPOON RGB</li>
                             <li>HARPOON RGB PRO</li>
@@ -184,6 +190,8 @@
                             <li>VOID WIRELESS</li>
                             <li>VOID PRO USB</li>
                             <li>VOID PRO WIRELESS</li>
+                            <li>VIRTUOSO RGB</li>
+                            <li>VIRTUOSO RGB SE</li>
                         </ul>
                     </li>
                     <li>Headset Stand:
@@ -194,7 +202,9 @@
                     <li>LED Controllers:
                         <ul>
                             <li>Lighting Node PRO</li>
+                            <li>Lighting Node CORE</li>
                             <li>Commander PRO</li>
+                            <li>iCUE LS100</li>
                         </ul>
                     </li>
                     <li>Memory module:


### PR DESCRIPTION
- add K70 RGB MK.2, STRAFE RGB MK.2, K95 RGB PLATINUM XT, M65 ELITE RGB, Scimitar ELITE RGB, IRONCLAW RGB, VIRTUOSO RGB, VIRTUOSO RGB SE, Lighting Node CORE, and iCUE LS100 to the list of supported devices.